### PR TITLE
Add note about how this fork is no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # oneshot
 
+**This fork of [`oneshot`](https://crates.io/crates/oneshot) is no longer required.
+The only reason this fork was created was to get rid of the `loom` dependency.
+Upstream `oneshot` has now solved that, by making `loom` an optional dependency.**
+
 Oneshot spsc (single producer, single consumer) channel. Meaning each channel instance
 can only transport a single message. This has a few nice outcomes. One thing is that
 the implementation can be very efficient, utilizing the knowledge that there will


### PR DESCRIPTION
Hi! I'm aware UniFFI [removed their dependency on `oneshot`](https://github.com/mozilla/uniffi-rs/pull/2096) completely. But I'm posting this anyway.

When I saw your fork of `oneshot` I felt bad for pulling in `loom` in downstream dependency trees. I had actually completely missed the fact that it did that in the first place. Cargo's dependency resolution is a bit lacking... My personal opinion is that it would have been nicer if you notified me of this problem. I would have fixed it, and you would not have needed a fork. That would have benefited all users downstream much earlier.

Now I have released `oneshot 0.1.8` that does not depend on `loom` at all.

I do not find it very nice that [`oneshot-uniffi`](https://crates.io/crates/oneshot-uniffi) points to *my* repository. That is not the source of truth for `oneshot-uniffi`.